### PR TITLE
Undefined names: import os, uuid, pandas in monitor.py

### DIFF
--- a/vel/openai/baselines/bench/monitor.py
+++ b/vel/openai/baselines/bench/monitor.py
@@ -5,9 +5,12 @@ from gym.core import Wrapper
 import time
 from glob import glob
 import csv
+import os
 import os.path as osp
 import json
+import uuid
 import numpy as np
+import pandas
 
 class Monitor(Wrapper):
     EXT = "monitor.csv"


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/MillionIntegrals/vel on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./vel/openai/baselines/bench/monitor.py:142:55: F821 undefined name 'uuid'
    mon_file = "/tmp/baselines-test-%s.monitor.csv" % uuid.uuid4()
                                                      ^
./vel/openai/baselines/bench/monitor.py:158:20: F821 undefined name 'pandas'
    last_logline = pandas.read_csv(f, index_col=None)
                   ^
./vel/openai/baselines/bench/monitor.py:161:5: F821 undefined name 'os'
    os.remove(mon_file)
    ^
3     F821 undefined name 'uuid'
3
```