### PR TITLE
Configurable Evaluator cache

### DIFF
--- a/vel/rl/test/test_evaluator_cache.py
+++ b/vel/rl/test/test_evaluator_cache.py
@@ -1,0 +1,39 @@
+from vel.rl.api import Evaluator, Rollout
+
+calls = {
+    "a": 0,
+    "b": 0,
+    "c": 0,
+}
+
+class TestEvaluator(Evaluator):
+    @Evaluator.provides('test:a')
+    def test_a(self):
+        calls["a"] += 1
+    
+    @Evaluator.provides('test:b', cache=False)
+    def test_b(self):
+        calls["b"] += 1
+    
+    @Evaluator.provides('test:c')
+    def test_c(self):
+        calls["c"] += 1
+    
+
+def test_evaluator():
+    e = TestEvaluator(Rollout())
+    e.get("test:a")
+    e.get("test:a")
+    e.get("test:a")
+    
+    e.get("test:b")
+    e.get("test:b")
+    e.get("test:b")
+
+    e.get("test:c")
+    e.get("test:c")
+    e.get("test:c", cache=False)
+
+    assert calls["a"] == 1 # test:a is cached so just one call
+    assert calls["b"] == 3 # test:b is never cached so three calls
+    assert calls["c"] == 2 # test:c is cached but one call is not so two calls


### PR DESCRIPTION
Hi, first of all thank you for your amazing work, this framework should be the standard for ML with pytorch!
I was playing around with it and i needed to backward two times on the same part of a graph and with the Evaluator cache is not possible (or it may be using retain_graph=True but is a dirty solution) so I've added an argument both the the Evaluator decorator and to the .get function to control the caching behavior